### PR TITLE
Request Type and Relationship Table Data Providers

### DIFF
--- a/api/database.json
+++ b/api/database.json
@@ -386,5 +386,41 @@
       "name": "Synth",
       "id": 29
     }
-  ]
+  ],
+  "requests": [
+    {
+      "id": 1,
+      "type": "drums"
+    },
+    {
+      "id": 2,
+      "type": "guitar"
+    },
+    {
+      "id": 3,
+      "type": "bass"
+    },
+    {
+      "id": 5,
+      "type": "keys"
+    },
+    {
+      "id": 6,
+      "type": "strings"
+    },
+    {
+      "id": 7,
+      "type": "brass"
+    },
+    {
+      "id": 7,
+      "type": "surprise me"
+    }
+  ],
+  "requestSongRelationships": [{
+    "id": 1,
+    "songId": 1,
+    "requestId": 2,
+    "userId": 2
+  }]
 }

--- a/src/components/requestSongRelationships/RequestSongProvider.js
+++ b/src/components/requestSongRelationships/RequestSongProvider.js
@@ -1,0 +1,41 @@
+import React, {useState} from 'react'
+
+export const RequestSongContext = React.createContext()
+
+export const RequestSongProvider = props => {
+    const [requestSongs, setRequestSongs] = useState([])
+
+    const getRequestSongs = () => {
+        return fetch("http://localhost:8088/requestsongrelationships/?_expand=request")
+            .then(res => res.json())
+            .then(setRequestSongs)
+    }
+
+    const addRequestSong = (relationshipObj) => {
+        return fetch("http://localhost:8088/requestsongrelationships", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify(relationshipObj)
+        })
+            .then(getRequestSongs)
+    }
+
+    const deleteRequestSong = relationshipId => {
+        return fetch(`http://localhost:8088/requestsongrelationships/${relationshipId}`, {
+            method: "DELETE"
+        })
+            .then(getRequestSongs)
+    }
+
+    return (
+        <RequestSongContext.Provider value={
+            {
+                requestSongs, getRequestSongs, addRequestSong, deleteRequestSong
+            }
+        }>
+            {props.children}
+        </RequestSongContext.Provider>
+    )
+}

--- a/src/components/requests/RequestProvider.js
+++ b/src/components/requests/RequestProvider.js
@@ -1,0 +1,23 @@
+import React, {useState} from 'react'
+
+export const RequestContext = React.createContext()
+
+export const RequestProvider = props => {
+    const [requests, setRequests] = useState([])
+
+    const getRequests = () => {
+        return fetch("http://localhost:8088/requests")
+            .then(res => res.json())
+            .then(setRequests)
+    }
+
+    return (
+        <RequestContext.Provider value={
+            {
+                requests, getRequests
+            }
+        }>
+            {props.children}
+        </RequestContext.Provider>
+    )
+}


### PR DESCRIPTION
# Description
Added two data providers and tables in my database. One table holds the request types so users can specify what they are looking for from other users when uploading an incomplete track. Also, users looking to contribute will be able to filter the browse list by requests. The second table added is a relationship table between songs and requests.

## Type of change
- [x] New feature (non-breaking change which adds functionality)


