### PR TITLE
Requests Added to Details Page

### DIFF
--- a/api/database.json
+++ b/api/database.json
@@ -142,6 +142,17 @@
       "incompleteDescription": "looking for lots of stuff on this drums / guitar track. surprise me!",
       "completeDescription": "",
       "id": 13
+    },
+    {
+      "userId": 4,
+      "songName": "Synth and Drums",
+      "incompleteURL": "https://firebasestorage.googleapis.com/v0/b/featurist.appspot.com/o/audio%2Frs09%20is%20a%20star%20bounce%2011.29.20.wav?alt=media&token=90172ef5-7b02-4f5a-b98d-c4c80e95cac9",
+      "completeURL": "",
+      "incompleteTimestamp": 1608218008333,
+      "completeTimestamp": "",
+      "incompleteDescription": "I would love to hear some guitar leads and bass on this synth and drum track.",
+      "completeDescription": "",
+      "id": 14
     }
   ],
   "users": [
@@ -433,7 +444,8 @@
       "songId": 12,
       "requestId": 5,
       "id": 1
-    },
+    }
+    ,
     {
       "songId": 12,
       "requestId": 1,
@@ -478,6 +490,22 @@
       "songId": 12,
       "requestId": 7,
       "id": 10
+    },
+    {
+      "songId": 14,
+      "requestId": 2,
+      "id": 11
+    },
+    {
+      "songId": 14,
+      "requestId": 3,
+      "id": 12
+    },
+    {
+      "songId": 14,
+      "requestId": 7,
+      "id": 13
     }
   ]
 }
+

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -44,33 +44,37 @@ export const ApplicationViews = props => {
             <SongProvider>
                 <UserProvider>
                     <StemProvider>
-                        <Route path="/song/:songId(\d+)" render={
-                            props => <SongDetail {...props} />
-                        } />
-                        <Route path="/song/complete/:songId(\d+)" render={
-                            props => <CompleteSongForm {...props} />
-                        } />
-                        <Route path="/song/stem/:songId(\d+)" render={
-                            props => <StemForm {...props} />
-                        } />
-                        <Route path="/profile/incomplete/:userId(\d+)" render={
-                            props => <ProfileIncompleteList {...props} />
-                        } />
-                        <Route exact path="/profile/incomplete" render={
-                            props => <ProfileIncompleteList {...props} />
-                        } />
-                        <Route path="/profile/complete/:userId(\d+)" render={
-                            props => <ProfileCompleteList {...props} />
-                        } />
-                        <Route exact path="/profile/complete" render={
-                            props => <ProfileCompleteList {...props} />
-                        } />
-                        <Route path="/profile/stem/:userId(\d+)" render={
-                            props => <ProfileStemList {...props} />
-                        } />
-                        <Route exact path="/profile/stem" render={
-                            props => <ProfileStemList {...props} />
-                        } />
+                        <RequestSongProvider>
+                            <RequestProvider>
+                                <Route path="/song/:songId(\d+)" render={
+                                    props => <SongDetail {...props} />
+                                } />
+                                <Route path="/song/complete/:songId(\d+)" render={
+                                    props => <CompleteSongForm {...props} />
+                                } />
+                                <Route path="/song/stem/:songId(\d+)" render={
+                                    props => <StemForm {...props} />
+                                } />
+                                <Route path="/profile/incomplete/:userId(\d+)" render={
+                                    props => <ProfileIncompleteList {...props} />
+                                } />
+                                <Route exact path="/profile/incomplete" render={
+                                    props => <ProfileIncompleteList {...props} />
+                                } />
+                                <Route path="/profile/complete/:userId(\d+)" render={
+                                    props => <ProfileCompleteList {...props} />
+                                } />
+                                <Route exact path="/profile/complete" render={
+                                    props => <ProfileCompleteList {...props} />
+                                } />
+                                <Route path="/profile/stem/:userId(\d+)" render={
+                                    props => <ProfileStemList {...props} />
+                                } />
+                                <Route exact path="/profile/stem" render={
+                                    props => <ProfileStemList {...props} />
+                                } />
+                            </RequestProvider>
+                        </RequestSongProvider>
                     </StemProvider>
                 </UserProvider>
             </SongProvider>

--- a/src/components/songs/IncompleteSongs/IncompleteForm.js
+++ b/src/components/songs/IncompleteSongs/IncompleteForm.js
@@ -64,7 +64,7 @@ export const IncompleteSongForm = props => {
                     })
                 })
                 // take user to browse page after upload
-                .then(() => props.history.push('/'))
+                .then(() => props.history.push('/profile/incomplete'))
             })
         })
     }
@@ -92,7 +92,6 @@ export const IncompleteSongForm = props => {
                 <input type="file" className="form__file"
                         onChange={evt => {
                             setFile(evt.target.files[0])
-                            console.log(file.name)
                         }}>
                 </input>
 

--- a/src/components/songs/SongDetails.js
+++ b/src/components/songs/SongDetails.js
@@ -5,19 +5,24 @@ import { StemCard } from '../stems/StemCard'
 import './Song.css'
 import { CompleteSongCard } from './CompleteSongs/CompleteSongCard'
 import { IncompleteSongCard } from './IncompleteSongs/IncompleteSongCard'
+import { RequestSongContext } from '../requestSongRelationships/RequestSongProvider'
 
 export const SongDetail = props => {
     const {songs, getSongs} = useContext(SongContext)
     const {stems, getStems} = useContext(StemContext)
+    const { requestSongs, getRequestSongs } = useContext(RequestSongContext)
 
     // set individual song object
     const [song, setSong] = useState({})
     // filtered stem array
     const [filteredStems, setStems] = useState([])
+    // request song relationships
+    const [relationships, setRelationships] = useState([])
 
     useEffect(() => {
         getSongs()
         .then(getStems)
+        .then(getRequestSongs)
     }, [])
 
     // find the song id and set the state
@@ -31,6 +36,12 @@ export const SongDetail = props => {
         const filteredStems = stems.filter(s => s.songId === parseInt(props.match.params.songId)) 
         setStems(filteredStems)
     }, [stems])
+
+    // find the request relationship tables for this song
+    useEffect(() => {
+        const relationships = requestSongs.filter(rel => rel.songId === parseInt(props.match.params.songId))
+        setRelationships(relationships)
+    }, [requestSongs])
 
     
     return (
@@ -59,7 +70,7 @@ export const SongDetail = props => {
                             ? <h2 className="stems__header">stem submissions</h2>
                             : <h2 className="stems__header">stem submission</h2>
                         )
-                        : ""
+                        : "no stem submissions yet"
                     }
                     
                     {
@@ -99,6 +110,18 @@ export const SongDetail = props => {
                         <div className='song__description'>{song.incompleteDescription}</div>
                         </div>    
                         }
+
+                    {relationships.length
+                        ? <div className='song__requests'>
+                        <h3 className='song__requestHeading'>looking for:</h3>
+                        {relationships.map((req)=> {
+                            return <div key={req.request.id} className='request'>{req.request.type}</div>
+                        })}
+
+                        </div> 
+                        :""
+                    }
+
                         
             </section>
 

--- a/src/components/users/UserCompleteList.js
+++ b/src/components/users/UserCompleteList.js
@@ -44,8 +44,7 @@ export const ProfileCompleteList = (props) => {
         }
     }, [users])
 
-    if(user.length){
-        console.log(user);}
+
     return (
         <div className="profile">
             <Route render={props => <ProfileNavBar {...props} />} /> 


### PR DESCRIPTION
# Description
If a user specifies a request on the incomplete form, the request(s) are now listed on the song details page. If requests were not selected on the form, this section will not render.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
